### PR TITLE
Fix README code ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,16 @@
 ```css
 /* before */
 .foo {
-    break-inside: avoid;
-    
-    break-after: page;
+  break-inside: avoid;
+  break-after: page;
 }
 
 /* after */
 .foo {
-  break-inside: avoid;
   page-break-inside: avoid;
-  
-  break-after: page;
+  break-inside: avoid;
   page-break-after: always;
+  break-after: page;
 }
 ```
 


### PR DESCRIPTION
Re: https://github.com/jonathantneal/postcss-preset-env/issues/11#issuecomment-366553149

I think the demo has the code order backwards, which concerned me until I looked into your source and tests.

The demos show:

```
.foo {
    break-inside: avoid;
}
```

Becoming

```
.foo {
  break-inside: avoid;
  page-break-inside: avoid;
}
```

But I think it actually becomes:

```
.foo {
  page-break-inside: avoid;
  break-inside: avoid;
}
```

Which is more future-compatible behavior.